### PR TITLE
Add flexible GraphQL query tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # GraphQLQeurier
+
+This repository contains a small Python utility for executing GraphQL queries and exporting the results as CSV. The tool is designed to handle dynamic attribute selections so the resulting table adapts to the columns requested in the query.
+
+## Requirements
+
+- Python 3.12 or newer
+- `requests` library (install via `pip install requests`)
+
+## Usage
+
+1. Write your GraphQL query to a file, for example `sample_query.graphql`.
+2. Run the script with the GraphQL endpoint URL and the query file:
+
+```bash
+python3 query_graphql.py https://example.com/graphql sample_query.graphql -o result.csv
+```
+
+The optional `GRAPHQL_TOKEN` environment variable can be set if the endpoint requires bearer-token authentication.
+
+The generated CSV contains a header row with dynamic column names. Each column corresponds to the attributes requested in the GraphQL query.

--- a/query_graphql.py
+++ b/query_graphql.py
@@ -1,0 +1,80 @@
+import argparse
+import csv
+import json
+import os
+import sys
+import requests
+
+
+def load_query(path: str) -> str:
+    with open(path, 'r', encoding='utf-8') as f:
+        return f.read()
+
+
+def get_attribute_value(attribute: dict):
+    """Extract the actual value from a GraphQL attribute payload."""
+    for key, value in attribute.items():
+        if key in {"attributeDefinitionSystemName", "__typename"}:
+            continue
+        if isinstance(value, dict):
+            # handle nested structures such as enumValue { value }
+            if "value" in value:
+                return value["value"]
+        elif value is not None:
+            return value
+    return None
+
+
+def parse_information_objects(payload: dict):
+    objects = payload.get("data", {}).get("informationObjects", {}).get("data", [])
+    rows = []
+    attribute_names = set()
+    for obj in objects:
+        row = {"id": obj.get("id")}
+        for attr in obj.get("attributes", []):
+            name = attr.get("attributeDefinitionSystemName")
+            value = get_attribute_value(attr)
+            row[name] = value
+            attribute_names.add(name)
+        rows.append(row)
+    ordered_names = ["id"] + sorted(attribute_names)
+    return ordered_names, rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Execute a GraphQL query and output a table")
+    parser.add_argument("endpoint", help="GraphQL endpoint URL")
+    parser.add_argument("query_file", help="File containing the GraphQL query")
+    parser.add_argument("-o", "--output", help="Path to output CSV file. Default: stdout")
+    args = parser.parse_args()
+
+    headers = {"Content-Type": "application/json"}
+    token = os.environ.get("GRAPHQL_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    query = load_query(args.query_file)
+    response = requests.post(args.endpoint, json={"query": query}, headers=headers)
+    response.raise_for_status()
+    result = response.json()
+
+    headers_row, rows = parse_information_objects(result)
+
+    if args.output:
+        fh = open(args.output, "w", newline="", encoding="utf-8")
+    else:
+        fh = sys.stdout
+
+    writer = csv.DictWriter(fh, fieldnames=headers_row)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({k: row.get(k, "") for k in headers_row})
+
+    if args.output:
+        fh.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sample_query.graphql
+++ b/sample_query.graphql
@@ -1,0 +1,31 @@
+query informationObjects {
+    informationObjects(
+        options: { filterBy: { classDefinitionSystemName: { value: "Audit" } } }
+    ) {
+        data {
+            id
+            attributes(systemNames: ["Startdatum","Bezeichnung","Status_Audit"]) {
+                attributeDefinitionSystemName
+                ... on InformationDateAttribute {
+                    dateValue
+                }
+                ... on InformationStringAttribute {
+                    stringValue
+                }
+                
+                ... on InformationEnumAttribute {
+                    enumValue {
+                        value
+                    }
+                    enumValueId
+                }
+                ... on InformationNumberAttribute {
+                    numberValue
+                }
+                ... on InformationReferenceAttribute {
+                    informationObjectReferenceValueIds
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Python utility to run GraphQL queries and output CSV
- document usage in README
- provide an example query

## Testing
- `python3 query_graphql.py --help`


------
https://chatgpt.com/codex/tasks/task_e_686e19423eb883308bbc9e9947488602