### PR TITLE
Add BASE_URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # GraphQLQeurier
 
-A small Streamlit based frontend for querying the `grasp.wtf` GraphQL API.
+A small Streamlit based frontend for querying the GraphQL API. By default it
+targets `https://grasp.wtf` but you can override this using the `BASE_URL`
+environment variable.
 
 ## Usage
 
 ```bash
 streamlit run graphql_frontend.py
 ```
+
+Set the optional `BASE_URL` environment variable if you want to target a
+different host.
 
 The app requires username and password for authentication. After logging in you can provide:
 

--- a/graphql_frontend.py
+++ b/graphql_frontend.py
@@ -1,10 +1,12 @@
+import os
 import streamlit as st
 import requests
 import pandas as pd
 
 # === CONFIG ===
-AUTH_URL = "https://grasp.wtf/auth/realms/platform/protocol/openid-connect/token"
-GRAPHQL_ENDPOINT = "https://grasp.wtf/dynamicdb/v1/graphql"
+BASE_URL = os.getenv("BASE_URL", "https://grasp.wtf").rstrip("/")
+AUTH_URL = f"{BASE_URL}/auth/realms/platform/protocol/openid-connect/token"
+GRAPHQL_ENDPOINT = f"{BASE_URL}/dynamicdb/v1/graphql"
 CLIENT_ID = "frontend"
 
 # === AUTHENTICATION ===
@@ -108,7 +110,7 @@ def extract_table(data):
         return pd.DataFrame()
 
 # === STREAMLIT UI ===
-st.title("GraphQL Explorer (grasp.wtf)")
+st.title(f"GraphQL Explorer ({BASE_URL})")
 
 with st.form("login_form"):
     username = st.text_input("Benutzername")


### PR DESCRIPTION
## Summary
- make the API base URL configurable through `BASE_URL`
- document the new environment variable in the README

## Testing
- `python -m py_compile graphql_frontend.py`

------
https://chatgpt.com/codex/tasks/task_e_686e21f1078883308ca429679a7c9d8c